### PR TITLE
fix: get documents API and text files connector

### DIFF
--- a/selfie/api/documents.py
+++ b/selfie/api/documents.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import List, Optional
 
 from fastapi import APIRouter, Query
@@ -27,8 +28,8 @@ class FetchedDocument(BaseModel):
     id: int = Field(..., description="The unique identifier of the document")
     name: str = Field(..., description="The name of the document")
     size: int = Field(..., description="The size of the document")
-    created_at: str = Field(..., description="The timestamp of the document creation")
-    updated_at: str = Field(..., description="The timestamp of the document update")
+    created_at: datetime = Field(..., description="The timestamp of the document creation")
+    updated_at: datetime = Field(..., description="The timestamp of the document update")
     content_type: str = Field(..., description="The content type of the document")
     connector_name: str = Field(..., description="The name of the connector")
 

--- a/selfie/connectors/text_files/uischema.json
+++ b/selfie/connectors/text_files/uischema.json
@@ -1,8 +1,5 @@
 {
   "files": {
-    "ui:widget": "nativeFile",
-    "ui:options": {
-      "accept": ".json"
-    }
+    "ui:widget": "nativeFile"
   }
 }


### PR DESCRIPTION
This pulls in some fixes discovered in #30. It also implements hybrid search in a "disabled" state (same behavior as non-hybrid search).