### PR TITLE
Fix Permission Syntax

### DIFF
--- a/scripts/package-macos-app.sh
+++ b/scripts/package-macos-app.sh
@@ -7,7 +7,7 @@ APP_CONTENTS="${APP_DIR}/Contents"
 CERT="Developer ID Application: Corsali, Inc (G7QNBSSW44)"
 
 # Find and sign all executables, dylibs, and .so files
-find "$APP_CONTENTS" -type f \( -perm +111 -o -name "*.dylib" -o -name "*.so" \) -exec codesign --force --sign "$CERT" --timestamp --options runtime '{}' \+
+find "$APP_CONTENTS" -type f \( -perm /111 -o -name "*.dylib" -o -name "*.so" \) -exec codesign --force --sign "$CERT" --timestamp --options runtime '{}' \+
 
 # Sign the app bundle itself
 codesign --deep --force --verbose --timestamp --options runtime --sign "$CERT" "${APP_DIR}"


### PR DESCRIPTION
File: scripts/package-macos-app.sh
Update: Replaced -perm +111 with -perm /111 in the find command.
Reason: The old syntax is deprecated; the new one ensures compatibility across modern systems.