### PR TITLE
fix: enable JSON response mode on MCP transport

### DIFF
--- a/packages/server/src/routes/mcp.ts
+++ b/packages/server/src/routes/mcp.ts
@@ -62,14 +62,18 @@ export function mcpRoute(deps: McpRouteDeps): Hono {
       }
 
       // Pass authInfo to the MCP transport
-      const transport = new WebStandardStreamableHTTPServerTransport();
+      const transport = new WebStandardStreamableHTTPServerTransport({
+        enableJsonResponse: true,
+      });
       const server = createMcpServer(deps.mcpContext);
       await server.connect(transport);
       return transport.handleRequest(c.req.raw, { authInfo });
     }
 
     // No OAuth configured — open access (dev/local mode)
-    const transport = new WebStandardStreamableHTTPServerTransport();
+    const transport = new WebStandardStreamableHTTPServerTransport({
+      enableJsonResponse: true,
+    });
     const server = createMcpServer(deps.mcpContext);
     await server.connect(transport);
     return transport.handleRequest(c.req.raw);


### PR DESCRIPTION
## Summary
- Enables `enableJsonResponse: true` on `WebStandardStreamableHTTPServerTransport` in the MCP route
- Fixes tool execution errors when Claude connects through a proxy chain (Anthropic → Cloudflare → FRP tunnel → local server)

## Problem
The default SSE streaming mode sends HTTP 200 immediately, then writes tool results asynchronously as SSE events. When proxies sit between the MCP client and server, they can buffer, truncate, or close the SSE connection before the result event arrives. This causes Claude to receive `{"error": "Error occurred during tool execution"}` even though the server processed the request successfully.

## Fix
Setting `enableJsonResponse: true` makes each MCP response a single atomic `application/json` reply instead of a long-lived SSE stream. This is reliable through any number of intermediary proxies.

## Test plan
- [x] `list_files` tool call via Claude returns results instead of error
- [x] OAuth-authenticated and unauthenticated paths both patched
- [x] Verified end-to-end with DataConnect personal server through FRP tunnel

🤖 Generated with [Claude Code](https://claude.com/claude-code)